### PR TITLE
ci(dependabot): group kube dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
     commit-message:
       prefix: "fix(deps)"
       include: "scope"
+    groups:
+      kube-rs-k8s-openapi:
+        patterns:
+          - "kube"
+          - "k8s-openapi"


### PR DESCRIPTION
Group kube and k8s-openapi because they need to be upgraded together.