### PR TITLE
fix(annotations): change default pattern to ascii-only

### DIFF
--- a/src/annotations.rs
+++ b/src/annotations.rs
@@ -102,7 +102,7 @@ pub fn charset<'a>(obj: &'a Arc<Secret>, id: &str) -> AnnotationResult<&'a str> 
 
 pub fn pattern<'a>(obj: &'a Arc<Secret>, id: &str) -> AnnotationResult<&'a str> {
     let length_v1 = format!("v1.secret.runo.rocks/pattern-{}", id);
-    let default_pattern = "[\\S]";
+    let default_pattern = "[a-zA-Z0-9\\-\\_\\(\\)\\%\\$\\@]";
     _annotation_result(obj, length_v1, default_pattern)
 }
 


### PR DESCRIPTION
The default pattern used all unicode characters as a starting point, which led to unreadable secret strings. The new default uses only ASCII characters which improves the readability of the generated secret strings.