### PR TITLE
Support requeue-duration as parameter

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,16 @@
+use crate::k8s::K8s;
+
+#[derive(Copy, Clone)]
+pub struct RunoConfig {
+    pub(crate) k8s: K8s,
+    pub(crate) requeue_duration: u64,
+}
+
+impl RunoConfig {
+    pub fn build(k8s: K8s, requeue_duration: u64) -> RunoConfig {
+        RunoConfig {
+            k8s,
+            requeue_duration,
+        }
+    }
+}

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -99,7 +99,7 @@ fn build_security_context() -> Option<SecurityContext> {
     })
 }
 
-async fn create_or_replace(cj: CronJob, namespace: &str, k8s: &Arc<K8s>) {
+async fn create_or_replace(cj: CronJob, namespace: &str, k8s: &K8s) {
     let cronjobs: Api<CronJob> = Api::namespaced(K8s::get_client().await, namespace);
     let c = cronjobs.create(&k8s.get_post_params(), &cj).await;
     match c {
@@ -122,7 +122,7 @@ pub fn build_cron_name(obj: &Arc<Secret>, id: &str) -> String {
     format!("runo-renewal-{}-{}", trunc_obj_name, id)
 }
 
-pub async fn update(obj: &Arc<Secret>, kube: &Arc<K8s>) {
+pub async fn update(obj: &Arc<Secret>, k8s: &K8s) {
     match obj.namespace() {
         Some(namespace) => {
             for id in id_iter(obj) {
@@ -133,7 +133,7 @@ pub async fn update(obj: &Arc<Secret>, kube: &Arc<K8s>) {
                         id
                     );
                     let cj = build_cronjob(obj, obj.name_any().as_str(), &id);
-                    create_or_replace(cj, &namespace, kube).await
+                    create_or_replace(cj, &namespace, k8s).await
                 }
             }
         }

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -8,7 +8,7 @@ pub struct K8s {
 }
 
 impl K8s {
-    pub fn new(dry_run: bool) -> K8s {
+    pub fn build(dry_run: bool) -> K8s {
         if dry_run {
             info!("Running runo in dry-run mode!")
         }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -156,7 +156,7 @@ fn get_updated_secret(obj: &Arc<Secret>) -> Secret {
     }
 }
 
-pub async fn update(obj: &Arc<Secret>, k8s: &Arc<K8s>) {
+pub async fn update(obj: &Arc<Secret>, k8s: &K8s) {
     let secrets: Api<Secret> =
         Api::namespaced(K8s::get_client().await, obj.namespace().unwrap().as_str());
     match secrets

--- a/tests/test_main.rs
+++ b/tests/test_main.rs
@@ -40,3 +40,15 @@ fn dry_run() {
         .assert()
         .interrupted();
 }
+
+#[test]
+fn requeue_duration() {
+    let mut cmd = Command::cargo_bin("runo").unwrap();
+    cmd.arg("--requeue-duration")
+        .arg("10")
+        .arg("--http-port")
+        .arg("0")
+        .timeout(std::time::Duration::from_secs(1))
+        .assert()
+        .interrupted();
+}


### PR DESCRIPTION
This PR adds the possibility to support more complex configurations and uses this to add requeue duration as a parameter.

Fix #20 