### PR TITLE
ci(release): fix upload/download of digests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests
+          name: digests-${{ matrix.recipe }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -148,7 +148,8 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          name: digests
+          pattern: digests-*
+          merge-multiple: true
           path: /tmp/digests
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
This PR fixes the upload and download of digests, which is not working anymore because of a change in the upload action.

See https://github.com/actions/upload-artifact/issues/478