### PR TITLE
refactor: Deduplicate code and improve annotation spec

### DIFF
--- a/src/cron.rs
+++ b/src/cron.rs
@@ -40,7 +40,7 @@ fn build_cronjob_spec(
     id: &str,
 ) -> Option<CronJobSpec> {
     Some(CronJobSpec {
-        schedule: cron_spec.get_value().into(),
+        schedule: cron_spec.get_value(),
         job_template: JobTemplateSpec {
             spec: Some(JobSpec {
                 template: PodTemplateSpec {

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -15,7 +15,7 @@ fn build_cronjob(obj: &Arc<Secret>, secret_name: &str, id: &str) -> CronJob {
     let cron_spec = renewal_cron(obj, id);
     debug!(
         "Will create cron job with pattern {:?} for {:?} and id {}",
-        cron_spec.get_value(),
+        cron_spec.clone().get_value(),
         obj.name_any(),
         id
     );
@@ -35,7 +35,7 @@ fn build_cronjob_object_meta(cron_name: &str) -> ObjectMeta {
 }
 
 fn build_cronjob_spec(
-    cron_spec: AnnotationResult<&str>,
+    cron_spec: AnnotationResult<String>,
     secret_name: &str,
     id: &str,
 ) -> Option<CronJobSpec> {

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -27,10 +27,10 @@ pub fn generate_random_string(
     let random_string = if !charset.is_default() {
         Ok(generate_random_string_from_charset(
             length.get_value(),
-            charset.get_value(),
+            charset.get_value().as_str(),
         ))
     } else {
-        generate_random_string_from_pattern(length.get_value(), pattern.get_value())
+        generate_random_string_from_pattern(length.get_value(), pattern.get_value().as_str())
     };
     debug!("Generated random string: {:?}", random_string);
     random_string


### PR DESCRIPTION
This PR de-duplicates code and improves the annotation spec by using a central enum for all annotations instead of rewriting string definitions over and over again.