### PR TITLE
Add checksum per key configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2209,6 +2209,7 @@ dependencies = [
  "regex",
  "rstest",
  "serde",
+ "sha2",
  "sha3",
  "temp-env",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ actix-web = "4.8.0"
 anyhow = "1.0.91"
 clap = { version = "4.5.20", features = ["derive"] }
 time = "0.3.36"
+sha2 = "0.10.8"
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/src/annotations.rs
+++ b/src/annotations.rs
@@ -3,7 +3,7 @@ use kube::ResourceExt;
 use std::sync::Arc;
 use tracing::{debug, error};
 
-enum V1Annotation {
+pub enum V1Annotation {
     Charset,
     Generate,
     GeneratedAt,
@@ -14,7 +14,7 @@ enum V1Annotation {
 }
 
 impl V1Annotation {
-    fn key(&self) -> String {
+    pub fn key(&self) -> String {
         match *self {
             V1Annotation::Charset => "v1.secret.runo.rocks/charset".to_string(),
             V1Annotation::Generate => "v1.secret.runo.rocks/generate".to_string(),
@@ -25,7 +25,7 @@ impl V1Annotation {
             V1Annotation::RenewalCron => "v1.secret.runo.rocks/renewal-cron".to_string(),
         }
     }
-    fn value(&self, id: &str) -> String {
+    pub fn value(&self, id: &str) -> String {
         match *self {
             V1Annotation::Charset => format!("{}-{}", V1Annotation::Charset.key(), id),
             V1Annotation::Generate => format!("{}-{}", V1Annotation::Generate.key(), id),

--- a/src/annotations.rs
+++ b/src/annotations.rs
@@ -1,5 +1,6 @@
 use k8s_openapi::api::core::v1::Secret;
 use kube::ResourceExt;
+use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use tracing::{debug, error};
 
@@ -11,6 +12,7 @@ pub enum V1Annotation {
     Pattern,
     Renewal,
     RenewalCron,
+    ConfigChecksum,
 }
 
 impl V1Annotation {
@@ -23,6 +25,7 @@ impl V1Annotation {
             V1Annotation::Pattern => "v1.secret.runo.rocks/pattern".to_string(),
             V1Annotation::Renewal => "v1.secret.runo.rocks/renewal".to_string(),
             V1Annotation::RenewalCron => "v1.secret.runo.rocks/renewal-cron".to_string(),
+            V1Annotation::ConfigChecksum => "v1.secret.runo.rocks/config-checksum".to_string(),
         }
     }
     pub fn value(&self, id: &str) -> String {
@@ -34,6 +37,9 @@ impl V1Annotation {
             V1Annotation::Pattern => format!("{}-{}", V1Annotation::Pattern.key(), id),
             V1Annotation::Renewal => format!("{}-{}", V1Annotation::Renewal.key(), id),
             V1Annotation::RenewalCron => format!("{}-{}", V1Annotation::RenewalCron.key(), id),
+            V1Annotation::ConfigChecksum => {
+                format!("{}-{}", V1Annotation::ConfigChecksum.key(), id)
+            }
         }
     }
     fn default(&self) -> Option<String> {
@@ -47,6 +53,7 @@ impl V1Annotation {
             V1Annotation::Pattern => Some("[a-zA-Z0-9\\-\\_\\(\\)\\%\\$\\@]".to_string()),
             V1Annotation::Renewal => None,
             V1Annotation::RenewalCron => None,
+            V1Annotation::ConfigChecksum => None,
         }
     }
 }
@@ -91,6 +98,22 @@ pub fn needs_renewal(obj: &Arc<Secret>, id: &str) -> bool {
             false
         }
     }
+}
+
+pub fn create_checksum(obj: &Arc<Secret>, id: &str) -> String {
+    let mut hasher = Sha256::new();
+    for annotation in get_annotations_for_id(obj, id) {
+        hasher.update(annotation);
+    }
+    let hash = hasher.finalize();
+    format!("{:x}", hash)
+}
+
+fn get_annotations_for_id<'a>(obj: &'a Arc<Secret>, id: &'a str) -> Vec<&'a String> {
+    obj.annotations()
+        .keys()
+        .filter(|p| p.ends_with(format!("-{}", id).as_str()))
+        .collect()
 }
 
 pub fn has_cron(obj: &Arc<Secret>, id: &str) -> bool {
@@ -179,6 +202,11 @@ pub fn id_iter(obj: &Arc<Secret>) -> Vec<String> {
         .map(|p| p.replace(format!("{}-", V1Annotation::Generate.key()).as_str(), ""))
         .collect();
     ids
+}
+
+#[allow(dead_code)]
+pub fn checksum(obj: &Arc<Secret>, id: &str) -> AnnotationResult<String> {
+    _annotation_result(obj, V1Annotation::ConfigChecksum, id)
 }
 
 #[cfg(test)]
@@ -364,6 +392,16 @@ mod tests {
         assert_eq!(
             crate::annotations::key(&Arc::new(secret.clone()), "0").get_value(),
             value
+        );
+    }
+
+    #[rstest]
+    #[case("v1.secret.runo.rocks/config-checksum-0", "checksum")]
+    fn v1_config_checksum(#[case] key: String, #[case] value: String) {
+        let secret = build_secret_with_annotations(vec![(key, value.to_string())]);
+        assert_eq!(
+            crate::annotations::checksum(&Arc::new(secret), "0").get_value(),
+            value.to_string()
         );
     }
 }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -83,13 +83,14 @@ fn update_annotations(obj: &Arc<Secret>) -> BTreeMap<String, String> {
                 obj.name_any(),
                 id
             );
-            let generated_at_v1 = format!("v1.secret.runo.rocks/generated-at-{}", id);
+            let generated_at_v1 =
+                format!("{}-{}", annotations::V1Annotation::GeneratedAt.key(), id);
             let now: DateTime<Utc> = SystemTime::now().into();
             secret_annotations.insert(generated_at_v1, now.timestamp().to_string());
         }
         if needs_renewal(obj, id.as_str()) {
             secret_annotations.insert(
-                format!("v1.secret.runo.rocks/renewal-{}", id),
+                format!("{}-{}", annotations::V1Annotation::Renewal.key(), id),
                 "false".to_string(),
             );
         }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,4 +1,6 @@
-use crate::annotations::{already_generated, charset, id_iter, length, needs_renewal, pattern};
+use crate::annotations::{
+    already_generated, charset, create_checksum, id_iter, length, needs_renewal, pattern,
+};
 use chrono::{DateTime, Utc};
 use k8s_openapi::api::core::v1::Secret;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -94,6 +96,11 @@ fn update_annotations(obj: &Arc<Secret>) -> BTreeMap<String, String> {
                 "false".to_string(),
             );
         }
+        let checksum = create_checksum(obj, id.as_str());
+        debug!("Adding checksum {:?} for config with ID {:?}", checksum, id);
+        let checksum_v1: String =
+            format!("{}-{}", annotations::V1Annotation::ConfigChecksum.key(), id);
+        secret_annotations.insert(checksum_v1, checksum);
     }
     secret_annotations
 }
@@ -175,6 +182,7 @@ pub async fn update(obj: &Arc<Secret>, k8s: &K8s) {
 
 #[cfg(test)]
 mod tests {
+    use crate::annotations::create_checksum;
     use crate::secrets::{generate_random_string, update_annotations, update_data};
     use chrono::{DateTime, Utc};
     use k8s_openapi::api::core::v1::Secret;
@@ -324,5 +332,18 @@ mod tests {
         let data = update_data(&Arc::from(secret));
         assert!(data.contains_key("username"));
         assert!(data.get("username").is_some())
+    }
+
+    #[test]
+    fn test_update_annotations_creates_config_checksum() {
+        let key_1 = String::from("v1.secret.runo.rocks/generate-0");
+        let value_1 = String::from("username");
+        let secret = build_secret_with_annotations(vec![(key_1, value_1)]);
+        let annotations = update_annotations(&Arc::from(secret.clone()));
+        assert!(annotations.contains_key("v1.secret.runo.rocks/config-checksum-0"));
+        let checksum = annotations
+            .get("v1.secret.runo.rocks/config-checksum-0")
+            .unwrap();
+        assert_eq!(*checksum, create_checksum(&Arc::from(secret), "0"));
     }
 }


### PR DESCRIPTION
In order to be able to check, if the configuration for a secret entry changed, this PR adds a checksum of the configuration per key to every secret.