### PR TITLE
Don't touch already existing fields anymore but support overwrite annotation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -136,15 +136,4 @@ jobs:
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
-      - name: Download checksum folders
-        uses: actions/download-artifact@v4
-      - name: Merge checksum.txt files
-        run: for i in  *-checksum ; do cat $i/checksum.txt >> checksums.txt; done
-      - name: Upload checksums.txt
-        uses: actions/upload-artifact@v4
-        with:
-          name: checksums
-          path: checksums.txt
-          if-no-files-found: error
-          retention-days: 5
       

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,41 +10,9 @@ env:
   IMAGE_NAME: ${{ github.repository }}-nightly
 
 jobs:
-  coverage:
-    name: Check test coverage with tarpaulin
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.12.0
-        with:
-          cluster_name: "kind"
-      - name: "Apply RBAC resources"
-        run: kubectl apply -k rbac
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-tarpaulin
-          version: latest
-      - run: cargo tarpaulin --timeout 300 -o Xml
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v5.1.2
-        with:
-          token: ${{secrets.CODECOV_TOKEN}}
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v4
-        with:
-          name: code-coverage-report
-          path: cobertura.xml
   build:
     name: Build a nightly version of runo
     runs-on: ubuntu-latest
-    needs: coverage
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -125,6 +125,23 @@ Sometimes its helpful or even necessary to rotate secrets after some time. rūn�
 
 ***Please note*** that not all use cases or applications support secret rotation. Please check carefully before using this feature. There is no history of field values and nobody wants to be locked-out of a production database because of that.
 
+v1.secret.runo.rocks/force-overwrite
+----
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: example-secret
+  labels:
+    v1.secret.runo.rocks/managed: "true"
+  annotations:
+    v1.secret.runo.rocks/generate-${ID}: ${FIELD_NAME} # Example: password
+    v1.secret.runo.rocks/force-overwrite-${ID}: true # Example: password
+type: Opaque
+data:
+```
+Annotation to enforce that runo overwrites a field which is already set, e.g. if you have an existing secret which should be managed afterwards by runo and you want to regenerate a single field. By default, runo ignores fields which are already set.
+
 ## Deployment
 
 Please deploy rūnō via the [available Helm chart](https://github.com/AljoschaP/runo-helm-chart).

--- a/src/annotations.rs
+++ b/src/annotations.rs
@@ -146,6 +146,7 @@ fn get_annotation_values_for_id<'a>(obj: &'a Arc<Secret>, id: &'a str) -> Vec<&'
     let annotations_for_id: Vec<(&String, &String)> = obj
         .annotations()
         .iter()
+        .filter(|p| !p.0.starts_with(V1Annotation::ConfigChecksum.key().as_str()))
         .filter(|p| p.0.ends_with(format!("-{}", id).as_str()))
         .collect();
     annotations_for_id.iter().map(|p| p.1).collect()

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,5 +1,5 @@
 use crate::annotations::{
-    already_generated, charset, create_checksum, id_iter, length, needs_renewal, pattern,
+    charset, create_checksum, id_iter, length, needs_generation, needs_renewal, pattern,
 };
 use chrono::{DateTime, Utc};
 use k8s_openapi::api::core::v1::Secret;
@@ -79,9 +79,9 @@ fn update_annotations(obj: &Arc<Secret>) -> BTreeMap<String, String> {
         None => BTreeMap::new(),
     };
     for id in id_iter(obj) {
-        if !already_generated(obj, id.as_str()) {
+        if needs_generation(obj, id.as_str()) {
             debug!(
-                "{:?} annotations for id {:?} need to be updated because not generated yet",
+                "{:?} annotations for id {:?} will be updated",
                 obj.name_any(),
                 id
             );
@@ -111,9 +111,9 @@ fn update_data(obj: &Arc<Secret>) -> BTreeMap<String, ByteString> {
         None => BTreeMap::new(),
     };
     for id in id_iter(obj) {
-        if !already_generated(obj, id.as_str()) {
+        if needs_generation(obj, id.as_str()) {
             debug!(
-                "{:?} data for id {:?} needs to be generated because not generated yet",
+                "{:?} data for id {:?} will be generated",
                 obj.name_any(),
                 id
             );
@@ -132,7 +132,7 @@ fn update_data_field(
     obj: &Arc<Secret>,
     id: &str,
 ) -> BTreeMap<String, ByteString> {
-    let key = annotations::key(obj, id);
+    let key = annotations::generate(obj, id);
     let value = generate_random_string(obj, id);
     match value {
         Ok(v) => {


### PR DESCRIPTION
This PR changes the behavior of runo in case a secret with fields already exists. Currently, runo overwrites those fields if there is an annotation with the same field name and it's not generated by runo indicated with the `v1.secret.runo.rocks/generated-at` annotation. This PR changes the behavior so that runo ignores those fields by default and you can enforce runo to overwrite them with the annotation `v1.secret.runo.rocks/force-overwrite`.