### PR TITLE
Don't allow regex patterns with quantifiers anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,13 @@ metadata:
   annotations:
     v1.secret.runo.rocks/generate-${ID}: ${FIELD_NAME} # Example: password
     v1.secret.runo.rocks/length-${ID}: ${LENGTH_OF_THE_VALUE} # Example: 5
-    v1.secret.runo.rocks/pattern-${ID}: ${CHARSET} # Example: abcd
+    v1.secret.runo.rocks/pattern-${ID}: ${PATTERN} # Example: [a-zA-Z0-9]
 type: Opaque
 data:
 ```
 A more powerful approach is the use of a regular expression to specify the pattern of the field. The generator is using the [rand_regex](https://crates.io/crates/rand_regex) crate for the actual generation.
+
+***Please note***: You can't use quantifiers `(e.g. +, ?, *, {1,10})` in the regex pattern.
 
 v1.secret.runo.rocks/renewal-cron
 ----

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ metadata:
     v1.secret.runo.rocks/managed: "true"
   annotations:
     v1.secret.runo.rocks/generate-${ID}: ${FIELD_NAME} # Example: password
-    v1.secret.runo.rocks/force-overwrite-${ID}: true # Example: password
+    v1.secret.runo.rocks/force-overwrite-${ID}: true
 type: Opaque
 data:
 ```

--- a/src/annotations.rs
+++ b/src/annotations.rs
@@ -135,7 +135,6 @@ pub fn needs_renewal(obj: &Arc<Secret>, id: &str) -> bool {
 pub fn create_checksum(obj: &Arc<Secret>, id: &str) -> String {
     let mut hasher = Sha256::new();
     for annotation in get_annotation_values_for_id(obj, id) {
-        println!("{}", annotation);
         hasher.update(annotation);
     }
     let hash = hasher.finalize();

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -35,3 +35,18 @@ impl fmt::Display for LogLevelMissing {
         write!(f, "RUST_LOG is not set properly!")
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct InvalidRegexPattern {
+    pub pattern: String,
+}
+
+impl fmt::Display for InvalidRegexPattern {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Invalid pattern {}! You can't use quantifiers (e.g. +, *, ? or {{}}) in regex pattern",
+            self.pattern
+        )
+    }
+}

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -207,6 +207,7 @@ mod tests {
     use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
     use regex::Regex;
+    use rstest::rstest;
     use std::collections::BTreeMap;
     use std::sync::Arc;
     use std::time::SystemTime;
@@ -284,6 +285,17 @@ mod tests {
         let key_1 = String::from("v1.secret.runo.rocks/pattern-0");
         let value_1 = String::from("");
         let secret = build_secret_with_annotations(vec![(key_1, value_1)]);
+        let result = generate_random_string(&Arc::from(secret), "0");
+        assert!(result.is_err())
+    }
+
+    #[rstest]
+    #[case("v1.secret.runo.rocks/pattern-0", "[abcd]+")]
+    #[case("v1.secret.runo.rocks/pattern-0", "[abcd]?")]
+    #[case("v1.secret.runo.rocks/pattern-0", "[abcd]*")]
+    #[case("v1.secret.runo.rocks/pattern-0", "[abcd]{1, 10}")]
+    fn test_generate_random_string_pattern_invalid(#[case] key: String, #[case] value: String) {
+        let secret = build_secret_with_annotations(vec![(key, value)]);
         let result = generate_random_string(&Arc::from(secret), "0");
         assert!(result.is_err())
     }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -9,7 +9,7 @@ use kube::api::Patch;
 use kube::{Api, ResourceExt};
 use rand::Rng;
 
-use crate::errors::CantCreateStringFromRegex;
+use crate::errors::{CantCreateStringFromRegex, InvalidRegexPattern};
 use std::collections::BTreeMap;
 
 use crate::annotations;
@@ -32,7 +32,13 @@ pub fn generate_random_string(
             charset.get_value().as_str(),
         ))
     } else {
-        generate_random_string_from_pattern(length.get_value(), pattern.get_value().as_str())
+        match validate_pattern(pattern.get_value().as_str()) {
+            Ok(p) => generate_random_string_from_pattern(length.get_value(), p),
+            Err(e) => {
+                error!("{}", e);
+                Err(CantCreateStringFromRegex)
+            }
+        }
     };
     debug!("Generated random string: {:?}", random_string);
     random_string
@@ -48,6 +54,18 @@ fn generate_random_string_from_charset(length: usize, charset: &str) -> String {
         })
         .collect();
     random_string
+}
+
+fn validate_pattern(pattern: &str) -> Result<&str, InvalidRegexPattern> {
+    let forbidden_chars = vec!["+", "?", "*", "{", "}"];
+    for char in forbidden_chars {
+        if pattern.contains(char) {
+            return Err(InvalidRegexPattern {
+                pattern: pattern.to_string(),
+            });
+        }
+    }
+    Ok(pattern)
 }
 
 fn generate_random_string_from_pattern(

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -175,8 +175,8 @@ pub async fn update(obj: &Arc<Secret>, k8s: &K8s) {
         )
         .await
     {
-        Ok(_) => info!("Secret patched successfully"),
-        Err(e) => error!("Can't patch secret: {:?}", e),
+        Ok(_) => info!("Secret reconciled successfully"),
+        Err(e) => error!("Couldn't reconcile secret: {:?}", e),
     }
 }
 


### PR DESCRIPTION
This PR adds code which validates the regex pattern to make sure that quantifiers are not part of the regex pattern. This is necessary because we apply the length annotation on top of the regex which fails if there is already a quantifier.