### PR TITLE
Improve error handling and support secret reconfiguration

### DIFF
--- a/src/annotations.rs
+++ b/src/annotations.rs
@@ -530,4 +530,41 @@ mod tests {
         secret.data = Some(predefined_data);
         assert!(crate::annotations::needs_generation(&Arc::new(secret), "0"));
     }
+
+    #[rstest]
+    #[case(vec![("v1.secret.runo.rocks/generate-0".to_string(), "username".to_string()),
+    ("v1.secret.runo.rocks/generated-at-0".to_string(), format!("{:?}",SystemTime::now())),
+    ("v1.secret.runo.rocks/generated-with-checksum-0".to_string(), "fghij".to_string()),
+    ("v1.secret.runo.rocks/config-checksum-0".to_string(), "abcde".to_string())])]
+    fn needs_generation_checksum_changed(#[case] annotations: Vec<(String, String)>) {
+        let secret = build_secret_with_annotations(annotations);
+        assert!(crate::annotations::needs_generation(&Arc::new(secret), "0"));
+    }
+
+    #[rstest]
+    #[case(vec![("v1.secret.runo.rocks/generate-0".to_string(), "username".to_string()),
+    ("v1.secret.runo.rocks/generated-at-0".to_string(), format!("{:?}",SystemTime::now())),
+    ("v1.secret.runo.rocks/generated-with-checksum-0".to_string(), "abcde".to_string()),
+    ("v1.secret.runo.rocks/config-checksum-0".to_string(), "abcde".to_string())])]
+    fn needs_no_generation_checksum_didnt_change(#[case] annotations: Vec<(String, String)>) {
+        let secret = build_secret_with_annotations(annotations);
+        assert!(!crate::annotations::needs_generation(
+            &Arc::new(secret),
+            "0"
+        ));
+    }
+
+    #[rstest]
+    #[case(vec![("v1.secret.runo.rocks/generate-0".to_string(), "username".to_string()),
+    ("v1.secret.runo.rocks/generated-at-0".to_string(), format!("{:?}",SystemTime::now())),
+    ("v1.secret.runo.rocks/config-checksum-0".to_string(), "abcde".to_string())])]
+    fn needs_no_generation_generated_with_checksum_doesnt_exist(
+        #[case] annotations: Vec<(String, String)>,
+    ) {
+        let secret = build_secret_with_annotations(annotations);
+        assert!(!crate::annotations::needs_generation(
+            &Arc::new(secret),
+            "0"
+        ));
+    }
 }

--- a/src/annotations.rs
+++ b/src/annotations.rs
@@ -301,9 +301,8 @@ mod tests {
     #[case("v1.secret.runo.rocks/generated-at-0", "000000000")]
     fn v1_already_generated_is_true(#[case] key: String, #[case] value: String) {
         let secret = build_secret_with_annotations(vec![(key, value)]);
-        assert_eq!(
-            crate::annotations::needs_renewal(&Arc::new(secret), "0"),
-            false
+        assert!(
+            !crate::annotations::needs_renewal(&Arc::new(secret), "0")
         );
     }
 
@@ -311,9 +310,8 @@ mod tests {
     #[case("v1.secret.runo.rocks/renewal-0", "true")]
     fn v1_needs_renewal_is_true(#[case] key: String, #[case] value: String) {
         let secret = build_secret_with_annotations(vec![(key, value)]);
-        assert_eq!(
-            crate::annotations::needs_renewal(&Arc::new(secret), "0"),
-            true
+        assert!(
+            crate::annotations::needs_renewal(&Arc::new(secret), "0")
         );
     }
 
@@ -321,9 +319,8 @@ mod tests {
     #[case("v1.secret.runo.rocks/not-a-valid-annotation", "true")]
     fn v1_no_valid_annotation(#[case] key: String, #[case] value: String) {
         let secret = build_secret_with_annotations(vec![(key, value)]);
-        assert_eq!(
-            crate::annotations::needs_renewal(&Arc::new(secret), "0"),
-            false
+        assert!(
+            !crate::annotations::needs_renewal(&Arc::new(secret), "0")
         );
     }
 
@@ -333,9 +330,8 @@ mod tests {
     #[case("v1.secret.runo.rocks/renewal-0", "")]
     fn v1_needs_renewal_parse_error(#[case] key: String, #[case] value: String) {
         let secret = build_secret_with_annotations(vec![(key, value)]);
-        assert_eq!(
-            crate::annotations::needs_renewal(&Arc::new(secret), "0"),
-            false
+        assert!(
+            !crate::annotations::needs_renewal(&Arc::new(secret), "0")
         );
     }
 
@@ -353,9 +349,8 @@ mod tests {
     #[case("v1.secret.runo.rocks/length-0", "1")]
     fn v1_length_returns_default(#[case] key: String, #[case] value: String) {
         let secret = build_secret_with_annotations(vec![(key, value)]);
-        assert_eq!(
-            crate::annotations::length(&Arc::new(secret), "1").is_default(),
-            true
+        assert!(
+            crate::annotations::length(&Arc::new(secret), "1").is_default()
         );
     }
 
@@ -365,9 +360,8 @@ mod tests {
     #[case("v1.secret.runo.rocks/length-0", "101")]
     fn v1_length_invalid(#[case] key: String, #[case] value: String) {
         let secret = build_secret_with_annotations(vec![(key, value)]);
-        assert_eq!(
-            crate::annotations::length(&Arc::new(secret), "0").is_default(),
-            true
+        assert!(
+            crate::annotations::length(&Arc::new(secret), "0").is_default()
         );
     }
 
@@ -385,9 +379,8 @@ mod tests {
     #[case("v1.secret.runo.rocks/charset-0", "")]
     fn v1_charset_returns_default(#[case] key: String, #[case] value: String) {
         let secret = build_secret_with_annotations(vec![(key, value)]);
-        assert_eq!(
-            crate::annotations::charset(&Arc::new(secret), "1").is_default(),
-            true
+        assert!(
+            crate::annotations::charset(&Arc::new(secret), "1").is_default()
         );
     }
 
@@ -405,9 +398,8 @@ mod tests {
     #[case("v1.secret.runo.rocks/pattern-0", "")]
     fn v1_pattern_returns_default(#[case] key: String, #[case] value: String) {
         let secret = build_secret_with_annotations(vec![(key, value)]);
-        assert_eq!(
-            crate::annotations::pattern(&Arc::new(secret), "1").is_default(),
-            true
+        assert!(
+            crate::annotations::pattern(&Arc::new(secret), "1").is_default()
         );
     }
 
@@ -425,9 +417,8 @@ mod tests {
     #[case("v1.secret.runo.rocks/generated-at-0", "")]
     fn v1_generated_at_returns_default(#[case] key: String, #[case] value: String) {
         let secret = build_secret_with_annotations(vec![(key, value)]);
-        assert_eq!(
-            crate::annotations::generated_at(&Arc::new(secret), "1").is_default(),
-            true
+        assert!(
+            crate::annotations::generated_at(&Arc::new(secret), "1").is_default()
         );
     }
 
@@ -435,15 +426,14 @@ mod tests {
     #[case("v1.secret.runo.rocks/renewal-cron-0", "true")]
     fn v1_has_cron_is_true(#[case] key: String, #[case] value: String) {
         let secret = build_secret_with_annotations(vec![(key, value)]);
-        assert_eq!(crate::annotations::has_cron(&Arc::new(secret), "0"), true);
+        assert!(crate::annotations::has_cron(&Arc::new(secret), "0"));
     }
 
     #[rstest]
     fn v1_cron_renewal_cron_returns_default() {
         let secret = build_secret_with_annotations(vec![]);
-        assert_eq!(
-            crate::annotations::renewal_cron(&Arc::new(secret), "0").is_default(),
-            true
+        assert!(
+            crate::annotations::renewal_cron(&Arc::new(secret), "0").is_default()
         );
     }
 
@@ -499,9 +489,8 @@ mod tests {
     #[rstest]
     fn v1_force_overwrite_returns_default() {
         let secret = build_secret_with_annotations(vec![]);
-        assert_eq!(
-            crate::annotations::force_overwrite(&Arc::new(secret.clone()), "0").is_default(),
-            true
+        assert!(
+            crate::annotations::force_overwrite(&Arc::new(secret.clone()), "0").is_default()
         );
         assert_eq!(
             crate::annotations::force_overwrite(&Arc::new(secret), "0").get_value(),
@@ -513,9 +502,8 @@ mod tests {
     #[case(vec![("v1.secret.runo.rocks/generate-0".to_string(), "username".to_string())])]
     fn needs_generation(#[case] annotations: Vec<(String, String)>) {
         let secret = build_secret_with_annotations(annotations);
-        assert_eq!(
-            crate::annotations::needs_generation(&Arc::new(secret), "0"),
-            true
+        assert!(
+            crate::annotations::needs_generation(&Arc::new(secret), "0")
         );
     }
 
@@ -524,9 +512,8 @@ mod tests {
     ("v1.secret.runo.rocks/generated-at-0".to_string(), format!("{:?}",SystemTime::now()))])]
     fn needs_no_generation_already_generated(#[case] annotations: Vec<(String, String)>) {
         let secret = build_secret_with_annotations(annotations);
-        assert_eq!(
-            crate::annotations::needs_generation(&Arc::new(secret), "0"),
-            false
+        assert!(
+            !crate::annotations::needs_generation(&Arc::new(secret), "0")
         );
     }
 
@@ -540,9 +527,8 @@ mod tests {
             ByteString("already-set".to_string().into_bytes()),
         );
         secret.data = Some(predefined_data);
-        assert_eq!(
-            crate::annotations::needs_generation(&Arc::new(secret), "0"),
-            false
+        assert!(
+            !crate::annotations::needs_generation(&Arc::new(secret), "0")
         );
     }
 
@@ -559,9 +545,8 @@ mod tests {
             ByteString("already-set".to_string().into_bytes()),
         );
         secret.data = Some(predefined_data);
-        assert_eq!(
-            crate::annotations::needs_generation(&Arc::new(secret), "0"),
-            true
+        assert!(
+            crate::annotations::needs_generation(&Arc::new(secret), "0")
         );
     }
 }

--- a/src/annotations.rs
+++ b/src/annotations.rs
@@ -110,7 +110,10 @@ pub fn needs_generation(obj: &Arc<Secret>, id: &str) -> bool {
         if generated_at(obj, id).exists() {
             let checksum = checksum(obj, id);
             let generated_with_checksum = generated_with_checksum(obj, id);
-            if checksum.exists() && generated_with_checksum.exists() && checksum.get_value() != generated_with_checksum.get_value() {
+            if checksum.exists()
+                && generated_with_checksum.exists()
+                && (checksum.get_value() != generated_with_checksum.get_value())
+            {
                 info!("(Re)generation of secret because checksum changed");
                 return true;
             }
@@ -303,27 +306,21 @@ mod tests {
     #[case("v1.secret.runo.rocks/generated-at-0", "000000000")]
     fn v1_already_generated_is_true(#[case] key: String, #[case] value: String) {
         let secret = build_secret_with_annotations(vec![(key, value)]);
-        assert!(
-            !crate::annotations::needs_renewal(&Arc::new(secret), "0")
-        );
+        assert!(!crate::annotations::needs_renewal(&Arc::new(secret), "0"));
     }
 
     #[rstest]
     #[case("v1.secret.runo.rocks/renewal-0", "true")]
     fn v1_needs_renewal_is_true(#[case] key: String, #[case] value: String) {
         let secret = build_secret_with_annotations(vec![(key, value)]);
-        assert!(
-            crate::annotations::needs_renewal(&Arc::new(secret), "0")
-        );
+        assert!(crate::annotations::needs_renewal(&Arc::new(secret), "0"));
     }
 
     #[rstest]
     #[case("v1.secret.runo.rocks/not-a-valid-annotation", "true")]
     fn v1_no_valid_annotation(#[case] key: String, #[case] value: String) {
         let secret = build_secret_with_annotations(vec![(key, value)]);
-        assert!(
-            !crate::annotations::needs_renewal(&Arc::new(secret), "0")
-        );
+        assert!(!crate::annotations::needs_renewal(&Arc::new(secret), "0"));
     }
 
     #[rstest]
@@ -332,9 +329,7 @@ mod tests {
     #[case("v1.secret.runo.rocks/renewal-0", "")]
     fn v1_needs_renewal_parse_error(#[case] key: String, #[case] value: String) {
         let secret = build_secret_with_annotations(vec![(key, value)]);
-        assert!(
-            !crate::annotations::needs_renewal(&Arc::new(secret), "0")
-        );
+        assert!(!crate::annotations::needs_renewal(&Arc::new(secret), "0"));
     }
 
     #[rstest]
@@ -351,9 +346,7 @@ mod tests {
     #[case("v1.secret.runo.rocks/length-0", "1")]
     fn v1_length_returns_default(#[case] key: String, #[case] value: String) {
         let secret = build_secret_with_annotations(vec![(key, value)]);
-        assert!(
-            crate::annotations::length(&Arc::new(secret), "1").is_default()
-        );
+        assert!(crate::annotations::length(&Arc::new(secret), "1").is_default());
     }
 
     #[rstest]
@@ -362,9 +355,7 @@ mod tests {
     #[case("v1.secret.runo.rocks/length-0", "101")]
     fn v1_length_invalid(#[case] key: String, #[case] value: String) {
         let secret = build_secret_with_annotations(vec![(key, value)]);
-        assert!(
-            crate::annotations::length(&Arc::new(secret), "0").is_default()
-        );
+        assert!(crate::annotations::length(&Arc::new(secret), "0").is_default());
     }
 
     #[rstest]
@@ -381,9 +372,7 @@ mod tests {
     #[case("v1.secret.runo.rocks/charset-0", "")]
     fn v1_charset_returns_default(#[case] key: String, #[case] value: String) {
         let secret = build_secret_with_annotations(vec![(key, value)]);
-        assert!(
-            crate::annotations::charset(&Arc::new(secret), "1").is_default()
-        );
+        assert!(crate::annotations::charset(&Arc::new(secret), "1").is_default());
     }
 
     #[rstest]
@@ -400,9 +389,7 @@ mod tests {
     #[case("v1.secret.runo.rocks/pattern-0", "")]
     fn v1_pattern_returns_default(#[case] key: String, #[case] value: String) {
         let secret = build_secret_with_annotations(vec![(key, value)]);
-        assert!(
-            crate::annotations::pattern(&Arc::new(secret), "1").is_default()
-        );
+        assert!(crate::annotations::pattern(&Arc::new(secret), "1").is_default());
     }
 
     #[rstest]
@@ -419,9 +406,7 @@ mod tests {
     #[case("v1.secret.runo.rocks/generated-at-0", "")]
     fn v1_generated_at_returns_default(#[case] key: String, #[case] value: String) {
         let secret = build_secret_with_annotations(vec![(key, value)]);
-        assert!(
-            crate::annotations::generated_at(&Arc::new(secret), "1").is_default()
-        );
+        assert!(crate::annotations::generated_at(&Arc::new(secret), "1").is_default());
     }
 
     #[rstest]
@@ -434,9 +419,7 @@ mod tests {
     #[rstest]
     fn v1_cron_renewal_cron_returns_default() {
         let secret = build_secret_with_annotations(vec![]);
-        assert!(
-            crate::annotations::renewal_cron(&Arc::new(secret), "0").is_default()
-        );
+        assert!(crate::annotations::renewal_cron(&Arc::new(secret), "0").is_default());
     }
 
     #[rstest]
@@ -491,9 +474,7 @@ mod tests {
     #[rstest]
     fn v1_force_overwrite_returns_default() {
         let secret = build_secret_with_annotations(vec![]);
-        assert!(
-            crate::annotations::force_overwrite(&Arc::new(secret.clone()), "0").is_default()
-        );
+        assert!(crate::annotations::force_overwrite(&Arc::new(secret.clone()), "0").is_default());
         assert_eq!(
             crate::annotations::force_overwrite(&Arc::new(secret), "0").get_value(),
             "false"
@@ -504,9 +485,7 @@ mod tests {
     #[case(vec![("v1.secret.runo.rocks/generate-0".to_string(), "username".to_string())])]
     fn needs_generation(#[case] annotations: Vec<(String, String)>) {
         let secret = build_secret_with_annotations(annotations);
-        assert!(
-            crate::annotations::needs_generation(&Arc::new(secret), "0")
-        );
+        assert!(crate::annotations::needs_generation(&Arc::new(secret), "0"));
     }
 
     #[rstest]
@@ -514,9 +493,10 @@ mod tests {
     ("v1.secret.runo.rocks/generated-at-0".to_string(), format!("{:?}",SystemTime::now()))])]
     fn needs_no_generation_already_generated(#[case] annotations: Vec<(String, String)>) {
         let secret = build_secret_with_annotations(annotations);
-        assert!(
-            !crate::annotations::needs_generation(&Arc::new(secret), "0")
-        );
+        assert!(!crate::annotations::needs_generation(
+            &Arc::new(secret),
+            "0"
+        ));
     }
 
     #[rstest]
@@ -529,9 +509,10 @@ mod tests {
             ByteString("already-set".to_string().into_bytes()),
         );
         secret.data = Some(predefined_data);
-        assert!(
-            !crate::annotations::needs_generation(&Arc::new(secret), "0")
-        );
+        assert!(!crate::annotations::needs_generation(
+            &Arc::new(secret),
+            "0"
+        ));
     }
 
     #[rstest]
@@ -547,8 +528,6 @@ mod tests {
             ByteString("already-set".to_string().into_bytes()),
         );
         secret.data = Some(predefined_data);
-        assert!(
-            crate::annotations::needs_generation(&Arc::new(secret), "0")
-        );
+        assert!(crate::annotations::needs_generation(&Arc::new(secret), "0"));
     }
 }

--- a/src/annotations.rs
+++ b/src/annotations.rs
@@ -2,7 +2,7 @@ use k8s_openapi::api::core::v1::Secret;
 use kube::ResourceExt;
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 pub enum V1Annotation {
     Charset,
@@ -111,11 +111,13 @@ pub fn needs_generation(obj: &Arc<Secret>, id: &str) -> bool {
             let checksum = checksum(obj, id);
             let generated_with_checksum = generated_with_checksum(obj, id);
             if checksum.exists() && generated_with_checksum.exists() && checksum.get_value() != generated_with_checksum.get_value() {
+                info!("(Re)generation of secret because checksum changed");
                 return true;
             }
         } else if !already_set(obj, id) {
             return true;
         } else if should_force_overwrite(obj, id) {
+            info!("Overwrite existing field because annotation is set");
             return true;
         }
     }

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -162,6 +162,6 @@ mod tests {
     fn test_build_cronjob() {
         let secret = Arc::from(build_secret());
         let cronjob = build_cronjob(&secret, "test-secret", "0");
-        assert_eq!(build_cron_name(&*Arc::new(secret), "0"), cronjob.name_any())
+        assert_eq!(build_cron_name(&secret, "0"), cronjob.name_any())
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,3 +50,30 @@ impl fmt::Display for InvalidRegexPattern {
         )
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct DataUpdateError;
+
+impl fmt::Display for DataUpdateError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Data update failed!",)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AnnotationUpdateError;
+
+impl fmt::Display for AnnotationUpdateError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Annotation update failed!",)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SecretUpdateError;
+
+impl fmt::Display for SecretUpdateError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Secret update failed!",)
+    }
+}

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -64,11 +64,11 @@ mod tests {
 
     #[rstest]
     fn v1_unmanaged_secret_explicitly(unmanaged_secret_explicitly: Arc<Secret>) {
-        assert_eq!(managed_by_us(&unmanaged_secret_explicitly), false);
+        assert!(!managed_by_us(&unmanaged_secret_explicitly));
     }
 
     #[rstest]
     fn v1_unmanaged_secret_implicitly(unmanaged_secret_explicitly: Arc<Secret>) {
-        assert_eq!(managed_by_us(&unmanaged_secret_explicitly), false);
+        assert!(!managed_by_us(&unmanaged_secret_explicitly));
     }
 }

--- a/src/reconciler.rs
+++ b/src/reconciler.rs
@@ -178,8 +178,7 @@ mod tests {
             .unwrap()
             .data
             .unwrap()
-            .get("username")
-            .is_some());
+            .contains_key("username"));
         // Value for field password should be generated
         assert!(secrets
             .get(secret_name)
@@ -187,8 +186,7 @@ mod tests {
             .unwrap()
             .data
             .unwrap()
-            .get("password")
-            .is_some());
+            .contains_key("password"));
         secrets
             .delete(secret_name, &DeleteParams::default())
             .await
@@ -253,8 +251,7 @@ mod tests {
             .unwrap()
             .data
             .unwrap()
-            .get("password")
-            .is_some());
+            .contains_key("password"));
         secrets
             .delete(secret_name, &DeleteParams::default())
             .await
@@ -324,8 +321,7 @@ mod tests {
             .unwrap()
             .data
             .unwrap()
-            .get("password")
-            .is_some());
+            .contains_key("password"));
         secrets
             .delete(secret_name, &DeleteParams::default())
             .await

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -388,7 +388,6 @@ mod tests {
         let secret = build_secret_with_annotations(vec![(key_1, value_1)]);
         let data = update_data(&Arc::from(secret)).unwrap();
         assert!(data.contains_key("username"));
-        assert!(data.get("username").is_some())
     }
 
     #[test]

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -316,7 +316,7 @@ mod tests {
         let value_2 = String::from("\\S");
         let secret = build_secret_with_annotations(vec![(key_1, value_1), (key_2, value_2)]);
         let start: DateTime<Utc> = SystemTime::now().into();
-        let annotations = update_annotations(&Arc::from(secret));
+        let annotations = update_annotations(&Arc::from(secret)).unwrap();
         let end: DateTime<Utc> = SystemTime::now().into();
         assert!(annotations.contains_key("v1.secret.runo.rocks/generated-at-0"));
         assert!(annotations.contains_key("v1.secret.runo.rocks/config-checksum-0"));
@@ -338,7 +338,7 @@ mod tests {
         let key_2 = String::from("v1.secret.runo.rocks/renewal-0");
         let value_2 = String::from("true");
         let secret = build_secret_with_annotations(vec![(key_1, value_1), (key_2, value_2)]);
-        let annotations = update_annotations(&Arc::from(secret));
+        let annotations = update_annotations(&Arc::from(secret)).unwrap();
         assert!(annotations.contains_key("v1.secret.runo.rocks/renewal-0"));
         let needs_renewal: bool = annotations
             .get("v1.secret.runo.rocks/renewal-0")
@@ -353,7 +353,7 @@ mod tests {
         let key_1 = String::from("v1.secret.runo.rocks/renewal-0");
         let value_1 = String::from("false");
         let secret = build_secret_with_annotations(vec![(key_1, value_1)]);
-        let annotations = update_annotations(&Arc::from(secret));
+        let annotations = update_annotations(&Arc::from(secret)).unwrap();
         assert!(annotations.contains_key("v1.secret.runo.rocks/renewal-0"));
         let needs_renewal: bool = annotations
             .get("v1.secret.runo.rocks/renewal-0")
@@ -368,7 +368,7 @@ mod tests {
         let key_1 = String::from("v1.secret.runo.rocks/generate-0");
         let value_1 = String::from("username");
         let secret = build_secret_with_annotations(vec![(key_1, value_1)]);
-        let data = update_data(&Arc::from(secret));
+        let data = update_data(&Arc::from(secret)).unwrap();
         assert!(data.contains_key("username"));
         assert!(data.get("username").is_some())
     }
@@ -378,7 +378,7 @@ mod tests {
         let key_1 = String::from("v1.secret.runo.rocks/generate-0");
         let value_1 = String::from("username");
         let secret = build_secret_with_annotations(vec![(key_1, value_1)]);
-        let annotations = update_annotations(&Arc::from(secret.clone()));
+        let annotations = update_annotations(&Arc::from(secret.clone())).unwrap();
         assert!(annotations.contains_key("v1.secret.runo.rocks/config-checksum-0"));
         let checksum = annotations
             .get("v1.secret.runo.rocks/config-checksum-0")


### PR DESCRIPTION
This PR adds support for secret reconfiguration. Currently, if you change the annotation of a secret (e.g. length from 10 to 20), runo won't regenerate it. This PR adds this functionality based on evaluating the configuration checksum. It also improves the error handling as a preparation for the feature.

Fix https://github.com/aljoshare/runo/issues/263