### PR TITLE
fix: resolve dead code warnings in CI

### DIFF
--- a/src/cron.rs
+++ b/src/cron.rs
@@ -158,7 +158,7 @@ mod tests {
         }
     }
 
-    #[cfg(test)]
+    #[test]
     fn test_build_cronjob() {
         let secret = Arc::from(build_secret());
         let cronjob = build_cronjob(&secret, "test-secret", "0");

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,15 +10,6 @@ impl fmt::Display for NoNamespaceForSecret {
 }
 
 #[derive(Debug, Clone)]
-pub struct AnnotationsDoesntExist;
-
-impl fmt::Display for AnnotationsDoesntExist {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "No annotations in metadata")
-    }
-}
-
-#[derive(Debug, Clone)]
 pub struct CantCreateStringFromRegex;
 
 impl fmt::Display for CantCreateStringFromRegex {


### PR DESCRIPTION
Fix dead code warnings that were causing the CI pipeline to fail on `cargo clippy`.

Signed-off-by: Jules <jules@example.com>

---
*PR created automatically by Jules for task [17095869741958684281](https://jules.google.com/task/17095869741958684281) started by @aljoshare*